### PR TITLE
configure travis to publish on github for each tagged commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,11 @@ after_success:
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASSWORD
   - docker images
   - docker push droupy/alma-server:latest
+
+deploy:
+  provider: releases
+  api_key: $GH_TOKEN
+  file: alma-server\target\alma-server-1.0.0-SNAPSHOT.jar
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ after_success:
 deploy:
   provider: releases
   api_key: $GH_TOKEN
-  file: alma-server\target\alma-server-1.0.0-SNAPSHOT.jar
+  file: alma-server/target/alma-server-1.0.0-SNAPSHOT.jar
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
add deploy parameters to make sure that Travis build publishes on Github a new release each time that a commit is tagged