### PR TITLE
Fix github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk: oraclejdk8
 branches:
   only:
     - master
+    - /v\d+\.\d+\.\d+/
 
 before_install:
   - docker version
@@ -23,7 +24,7 @@ script:
   - gulp minify
   - cd ../../../../
   - mvn clean verify -f alma-server/pom.xml -e
-  
+
 after_success:
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASSWORD
   - docker images


### PR DESCRIPTION
Travis seems to not recognize a tagged commit.
```
Skipping a deployment with the releases provider because this is not a tagged commit
```
From [this issue](https://github.com/travis-ci/travis-ci/issues/6730), Travis ignore tags. A [solution](http://stackoverflow.com/questions/30156581/travis-ci-skipping-deployment-although-commit-is-tagged) is to use regex in `branches`.